### PR TITLE
Added developer docs as a oauth consumer

### DIFF
--- a/configurator/gateway-config.py
+++ b/configurator/gateway-config.py
@@ -96,5 +96,6 @@ kong.ensure_keyauth_acl("admin", "admin")
 kong.ensure_oauth2_consumer("partupy", "Apper McAppface", "https://example.com/oauth2")
 kong.ensure_oauth2_consumer("jplattel", "Joost Plattel", "http://localhost:8000/callback")
 kong.ensure_oauth2_consumer("zapier", "Zapier", "https://zapier.com/dashboard/auth/oauth/return/App1327CLIAPI/")
+kong.ensure_oauth2_consumer("docs", "Part-up User API Documentation", "http://developer.part-up.com/oauth2-redirect.html")
 
 kong.remove_undefined_users()


### PR DESCRIPTION
This enables the developer documentation (developer.part-up.com) to have an OAuth flow. (Better experience for developers with personal results in the docs)